### PR TITLE
Fix crash at GetBitString when numBits is zero

### DIFF
--- a/aper.go
+++ b/aper.go
@@ -43,6 +43,9 @@ func GetBitString(srcBytes []byte, bitsOffset uint, numBits uint) (dstBytes []by
 	byteLen := (bitsOffset + numBits + 7) >> 3
 	numBitsByteLen := (numBits + 7) >> 3
 	dstBytes = make([]byte, numBitsByteLen)
+	if numBitsByteLen == 0 {
+		return
+	}
 	numBitsMask := byte(0xff)
 	if modEight := numBits & 0x7; modEight != 0 {
 		numBitsMask <<= uint8(8 - (modEight))

--- a/aper_test.go
+++ b/aper_test.go
@@ -505,6 +505,8 @@ var integerTestData = []testData{
 	{[]byte{0x01, 0x03}, intTest1Data[0]},
 	{[]byte{0x03, 0x05, 0x16, 0x15}, intTest1Data[1]},
 	{[]byte{0x03, 0xFA, 0xE9, 0xEB}, intTest1Data[2]},
+	// I don't know if I should treat it as an error in this case.
+	{[]byte{0x00}, intTest1{0}},
 	{[]byte{0x00}, intTest2Data[0]},
 	{[]byte{0x14}, intTest3Data[0]},
 	{[]byte{0x18}, intTest3Data[1]},


### PR DESCRIPTION
Fix for https://github.com/free5gc/free5gc/issues/402.
